### PR TITLE
adding submodule evm contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/evm"]
+	path = contracts/evm
+	url = https://github.com/questbook/grants-contracts-upgradeable.git


### PR DESCRIPTION
Linking questbook contracts as a submodule under `contracts/evm`
https://github.com/questbook/grants-contracts-upgradeable